### PR TITLE
chore: add logs only for github api rate

### DIFF
--- a/receiver.go
+++ b/receiver.go
@@ -150,13 +150,20 @@ func handleWorkflowRunEvent(
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	githubApiRate := []zap.Field{
+		zap.Int("github.api.rate-limit.core.limit", rateLimit.limit),
+		zap.Int("github.api.rate-limit.core.remaining", rateLimit.remaining),
+		zap.Time("github.api.rate-limit.core.reset", rateLimit.reset),
+	}
 	ghalr.logger.Info(
 		"GitHub Api Rate limits",
 		withWorkflowInfoFields(
-			zap.Int("github.api.rate-limit.core.limit", rateLimit.limit),
-			zap.Int("github.api.rate-limit.core.remaining", rateLimit.remaining),
-			zap.Time("github.api.rate-limit.core.reset", rateLimit.reset),
+			githubApiRate...,
 		)...,
+	)
+	// Use a subset of the fields to avoid issues with the logger processor
+	ghalr.logger.Info(
+		"GitHub Api Rate limits", githubApiRate...,
 	)
 }
 


### PR DESCRIPTION
Add a new trace for helping with monitoring the remaining rate api.